### PR TITLE
Fix locale setup timing in SelectionActivity

### DIFF
--- a/app/src/main/java/com/app/delmon/activity/SelectionActivity.kt
+++ b/app/src/main/java/com/app/delmon/activity/SelectionActivity.kt
@@ -24,9 +24,9 @@ class SelectionActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        setLocale("ar")
         binding = ActivitySelectionBinding.inflate(layoutInflater)
         setContentView(binding.root)
-        setLocale("ar")
 
         sharedHelper= SharedHelper(this)
 


### PR DESCRIPTION
## Summary
- ensure Arabic locale is set before view inflation

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6878c688bf788326aa34a1d614700859