### PR TITLE
Fix locale init and translations

### DIFF
--- a/app/src/main/java/com/app/delmon/Session/SharedHelper.kt
+++ b/app/src/main/java/com/app/delmon/Session/SharedHelper.kt
@@ -327,7 +327,7 @@ class SharedHelper(context: Context) {
             """.trimIndent()
         )
         builder.setCancelable(false)
-        builder.setPositiveButton(contextt.getString(R.string.pemitmanually),
+        builder.setPositiveButton(contextt.getString(R.string.permit_manually),
             DialogInterface.OnClickListener { dialog, which ->
                 dialog.dismiss()
                 val intent = Intent()

--- a/app/src/main/java/com/app/delmon/activity/SelectionActivity.kt
+++ b/app/src/main/java/com/app/delmon/activity/SelectionActivity.kt
@@ -54,10 +54,11 @@ class SelectionActivity : AppCompatActivity() {
     private fun setLocale(lang: String) {
         Log.d("TAG", "setLocale: $lang")
         val language = Locale(lang)
+        Locale.setDefault(language)
         val res: Resources = resources
         val dm: DisplayMetrics = res.displayMetrics
         val conf: Configuration = res.configuration
-        conf.locale = language
+        conf.setLocale(language)
         res.updateConfiguration(conf, dm)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
             res.configuration.setLayoutDirection(language)

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">دلمون</string>
-    <string name="pemitmanually">السماح يدويا</string>
-    <string name="cancel">الغاءl</string>
+    <string name="permit_manually">السماح يدويا</string>
+    <string name="cancel">الغاء</string>
     <string name="choose_your_option">إختر من الاسفل خيارك</string>
     <string name="gallery">الاستديو</string>
     <string name="camera">الكاميرا</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Delmon</string>
-    <string name="pemitmanually">Permit Manually</string>
+    <string name="permit_manually">Permit Manually</string>
     <string name="cancel">Cancel</string>
     <string name="choose_your_option">Choose Your Option</string>
     <string name="gallery">Gallery</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Delmon</string>
-    <string name="pemitmanually">Permit Manually</string>
-    <string name="cancel">Cancel</string>
-    <string name="choose_your_option">Choose Your Option</string>
-    <string name="gallery">Gallery</string>
-    <string name="camera">Camera</string>
-    <string name="no_internet_connection">No Internet Connection.. Please Try Again..</string>
-    <string name="time_out_error">TimeOut Error Please Try Again..</string>
-    <string name="session_expired">Session Expired. Login to continue</string>
-    <string name="server_error">Server Error.. Please Try Again..</string>
-    <string name="network_error">Network Error.. Please Try Again..</string>
-    <string name="parsing_error">Parse Error.. Please Try Again..</string>
-    <string name="permission_failed_error">You failed to give some permission, You can enable it in settings to proceed further.</string>
+    <string name="app_name">डेलमोन</string>
+    <string name="permit_manually">अनुमति मैन्युअली दें</string>
+    <string name="cancel">रद्द करें</string>
+    <string name="choose_your_option">अपना विकल्प चुनें</string>
+    <string name="gallery">गैलरी</string>
+    <string name="camera">कैमरा</string>
+    <string name="no_internet_connection">इंटरनेट कनेक्शन नहीं है... कृपया पुनः प्रयास करें</string>
+    <string name="time_out_error">समय समाप्त त्रुटि, कृपया पुनः प्रयास करें</string>
+    <string name="session_expired">सत्र समाप्त हो गया है। जारी रखने के लिए लॉगिन करें</string>
+    <string name="server_error">सर्वर त्रुटि... कृपया पुनः प्रयास करें</string>
+    <string name="network_error">नेटवर्क त्रुटि... कृपया पुनः प्रयास करें</string>
+    <string name="parsing_error">पार्स त्रुटि... कृपया पुनः प्रयास करें</string>
+    <string name="permission_failed_error">आप कुछ अनुमति देने में असफल रहे, आगे बढ़ने के लिए इसे सेटिंग में सक्षम कर सकते हैं।</string>
     <string name="map_api_key">AIzaSyA4RBfnVNqTWspqevUPtYdrCdwySQhwmRU</string>
     <string name="hello_blank_fragment" translatable="false">Hello blank fragment</string>
     <string name="menu_dashboard">Home</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <resources>
     <string name="app_name">Delmon</string>
-    <string name="pemitmanually">Permit Manually</string>
+    <string name="permit_manually">Permit Manually</string>
     <string name="cancel">Cancel</string>
     <string name="choose_your_option">Choose Your Option</string>
     <string name="gallery">Gallery</string>


### PR DESCRIPTION
## Summary
- apply locale before view inflation with `Locale.setDefault`
- fix Arabic cancel string
- rename `pemitmanually` resource to `permit_manually`
- translate some Hindi strings

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6878c4853d2083268c4f690226304ba7